### PR TITLE
This fixes the :on_error handlers so they actually work.

### DIFF
--- a/lib/metriks/reporter/graphite.rb
+++ b/lib/metriks/reporter/graphite.rb
@@ -11,7 +11,7 @@ module Metriks::Reporter
 
       @registry  = options[:registry] || Metriks::Registry.default
       @interval  = options[:interval] || 60
-      @on_errror = options[:on_error] || proc { |ex| }
+      @on_error  = options[:on_error] || proc { |ex| }
     end
 
     def socket

--- a/lib/metriks/reporter/librato_metrics.rb
+++ b/lib/metriks/reporter/librato_metrics.rb
@@ -11,7 +11,7 @@ module Metriks::Reporter
 
       @registry  = options[:registry] || Metriks::Registry.default
       @interval  = options[:interval] || 60
-      @on_errror = options[:on_error] || proc { |ex| }
+      @on_error  = options[:on_error] || proc { |ex| }
     end
 
     def start

--- a/lib/metriks/reporter/logger.rb
+++ b/lib/metriks/reporter/logger.rb
@@ -9,7 +9,7 @@ module Metriks::Reporter
 
       @registry  = options[:registry] || Metriks::Registry.default
       @interval  = options[:interval] || 60
-      @on_errror = options[:on_error] || proc { |ex| }
+      @on_error  = options[:on_error] || proc { |ex| }
     end
 
     def start

--- a/lib/metriks/reporter/proc_title.rb
+++ b/lib/metriks/reporter/proc_title.rb
@@ -5,7 +5,7 @@ module Metriks::Reporter
       @prefix   = options[:prefix]   || $0.dup
 
       @interval  = options[:interval] || 5
-      @on_errror = options[:on_error] || proc { |ex| }
+      @on_error  = options[:on_error] || proc { |ex| }
 
       @metrics  = []
     end
@@ -29,7 +29,7 @@ module Metriks::Reporter
               end
             end
           rescue Exception => ex
-            @on_errror[ex] rescue nil
+            @on_error[ex] rescue nil
           end
           sleep @interval
         end

--- a/test/graphite_reporter_test.rb
+++ b/test/graphite_reporter_test.rb
@@ -1,11 +1,18 @@
 require 'test_helper'
+require 'thread_error_handling_tests'
 
 require 'metriks/reporter/graphite'
 
 class GraphiteReporterTest < Test::Unit::TestCase
+  include ThreadErrorHandlingTests
+
+  def build_reporter(options={})
+    Metriks::Reporter::Graphite.new('localhost', 3333, { :registry => @registry }.merge(options))
+  end
+
   def setup
     @registry = Metriks::Registry.new
-    @reporter = Metriks::Reporter::Graphite.new('localhost', 3333, :registry => @registry)
+    @reporter = build_reporter
     @stringio = StringIO.new
 
     @reporter.stubs(:socket).returns(@stringio)

--- a/test/librato_metrics_reporter_test.rb
+++ b/test/librato_metrics_reporter_test.rb
@@ -1,11 +1,18 @@
 require 'test_helper'
+require 'thread_error_handling_tests'
 
 require 'metriks/reporter/librato_metrics'
 
 class LibratoMetricsReporterTest < Test::Unit::TestCase
+  include ThreadErrorHandlingTests
+
+  def build_reporter(options={})
+    Metriks::Reporter::LibratoMetrics.new('user', 'password', { :registry => @registry }.merge(options))
+  end
+
   def setup
     @registry = Metriks::Registry.new
-    @reporter = Metriks::Reporter::LibratoMetrics.new('user', 'password', :registry => @registry)
+    @reporter = build_reporter
   end
 
   def teardown

--- a/test/logger_reporter_test.rb
+++ b/test/logger_reporter_test.rb
@@ -1,15 +1,22 @@
 require 'test_helper'
+require 'thread_error_handling_tests'
 
 require 'logger'
 require 'metriks/reporter/logger'
 
 class LoggerReporterTest < Test::Unit::TestCase
+  include ThreadErrorHandlingTests
+
+  def build_reporter(options={})
+    Metriks::Reporter::Logger.new({ :registry => @registry, :logger => @logger }.merge(options))
+  end
+
   def setup
     @stringio = StringIO.new
     @logger   = ::Logger.new(@stringio)
     @registry = Metriks::Registry.new
 
-    @reporter = Metriks::Reporter::Logger.new(:registry => @registry, :logger => @logger)
+    @reporter = build_reporter
 
     @registry.meter('meter.testing').mark
     @registry.counter('counter.testing').increment

--- a/test/riemann_reporter_test.rb
+++ b/test/riemann_reporter_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'thread_error_handling_tests'
 
 # riemann only works in 1.9
 if RUBY_VERSION > '1.9'
@@ -6,14 +7,20 @@ if RUBY_VERSION > '1.9'
 require 'metriks/reporter/riemann'
 
 class RiemannReporterTest < Test::Unit::TestCase
-  def setup
-    @registry = Metriks::Registry.new
-    @reporter = Metriks::Reporter::Riemann.new(
+  include ThreadErrorHandlingTests
+
+  def build_reporter(options={})
+    Metriks::Reporter::Riemann.new({
       :host => "foo",
       :port => 1234,
       :registry => @registry,
       :default_event => {:host => "h"}
-    )
+    }.merge(options))
+  end
+
+  def setup
+    @registry = Metriks::Registry.new
+    @reporter = build_reporter
   end
 
   def teardown

--- a/test/thread_error_handling_tests.rb
+++ b/test/thread_error_handling_tests.rb
@@ -1,0 +1,20 @@
+module ThreadErrorHandlingTests
+  def test_passes_errors_in_thread_loop_to_on_error_handler
+    rescued_error = nil
+    error_handler_called = false
+    reporter = build_reporter(:interval => 0.0001, :on_error => lambda { |e|
+      error_handler_called = true
+      rescued_error = e
+    })
+
+    reporter.stubs(:write).raises(StandardError, "boom")
+
+    reporter.start
+    sleep 0.002
+    assert_equal true, error_handler_called
+    assert_equal "boom", rescued_error.message
+  ensure
+    reporter.stop
+  end
+end
+


### PR DESCRIPTION
They were fat-fingered in most of the reporters as @on_errror and thus
were silently ignored.
