### PR TITLE
Make it work on jruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,10 @@ source :rubygems
 
 gemspec
 
-gem 'rbtree'
+gem 'rbtree-pure'
 
 group :test do
   gem 'turn', '0.8.2', :require => false
   gem 'rake', '0.8.7'
-  gem 'riemann-client', :platform => :mri_19
+  gem 'riemann-client', '0.0.6'
 end


### PR DESCRIPTION
rbtree uses the Ruby C API, meaning that it doesn't play nicely with rubinius and jruby.
