### PR TITLE
Allow selection of which metrics to submit from Librato metrics reporter

### DIFF
--- a/lib/metriks/reporter/librato_metrics.rb
+++ b/lib/metriks/reporter/librato_metrics.rb
@@ -12,6 +12,12 @@ module Metriks::Reporter
       @registry  = options[:registry] || Metriks::Registry.default
       @interval  = options[:interval] || 60
       @on_error  = options[:on_error] || proc { |ex| }
+
+      if options[:only] and options[:except]
+        raise 'Can only specify one of :only or :except'
+      end
+      @only     = options[:only] || []
+      @except   = options[:except] || []
     end
 
     def start
@@ -119,6 +125,15 @@ module Metriks::Reporter
       base_name = base_name.to_s.gsub(/ +/, '_')
       if @prefix
         base_name = "#{@prefix}.#{base_name}"
+      end
+
+      if @only
+        keys = keys & @only
+        snapshot_keys = snapshot_keys & @only
+      end
+      if @except
+        keys = keys - @except
+        snapshot_keys = snapshot_keys - @except
       end
 
       keys.flatten.each do |key|


### PR DESCRIPTION
Can specific `:only` or `:except` when initializing the reporter, e.g.

``` ruby
Metriks::Reporter::LibratoMetrics.new(
  'email',
  'key',
  {
    prefix: 'example',
    only: [
      :count,
      :mean,
      :one_minute_rate
    ]
  }
).start
```
