### PR TITLE
Check for infinite sample keys

### DIFF
--- a/lib/metriks/exponentially_decaying_sample.rb
+++ b/lib/metriks/exponentially_decaying_sample.rb
@@ -39,6 +39,7 @@ module Metriks
     def update(value, timestamp = Time.now)
       @mutex.synchronize do
         priority = weight(timestamp - @start_time) / rand
+        priority = Float::MAX if priority.infinite?
         new_count = @count.update { |v| v + 1 }
 
         if priority.nan?

--- a/test/histogram_test.rb
+++ b/test/histogram_test.rb
@@ -185,4 +185,15 @@ class HistogramTest < Test::Unit::TestCase
 
     assert_equal 49.5, snapshot.median
   end
+
+  def test_long_idle_sample
+    Time.stubs(:now).returns(Time.new(2000))
+    sample = Metriks::ExponentiallyDecayingSample.new(Metriks::Histogram::DEFAULT_SAMPLE_SIZE, Metriks::Histogram::DEFAULT_ALPHA)
+    Time.unstub(:now)
+    @histogram = Metriks::Histogram.new(sample)
+
+    @histogram.update(5)
+
+    assert_equal 5, @histogram.min
+  end
 end


### PR DESCRIPTION
Fixes #13. Here's how I reproduced it.

``` ruby
sample = Metriks::ExponentiallyDecayingSample.new(Metriks::Histogram::DEFAULT_SAMPLE_SIZE, Metriks::Histogram::DEFAULT_ALPHA)

# Pretend the process has been running for a while without resampling.
sample.instance_variable_set(:@start_time, Time.new(2000))
sample.instance_variable_get(:@next_scale_time).value = Time.new(2000) + Metriks::ExponentiallyDecayingSample::RESCALE_THRESHOLD

sample.update 42
#=> warn: ExponentiallyDecayingSample found a new_key of NaN. key: Infinity old_start_time: 946702800.0 start_time: 1341235050.329391
```
