### PR TITLE
Optionally filter data reported to Librato Metrics

### DIFF
--- a/lib/metriks/reporter/librato_metrics.rb
+++ b/lib/metriks/reporter/librato_metrics.rb
@@ -15,6 +15,9 @@ module Metriks::Reporter
       @registry  = options[:registry] || Metriks::Registry.default
       @time_tracker = Metriks::TimeTracker.new(options[:interval] || 60)
       @on_error  = options[:on_error] || proc { |ex| }
+
+      @only   = options[:only]   || :all
+      @except = options[:except] || :none
     end
 
     def start
@@ -86,6 +89,22 @@ module Metriks::Reporter
       gauges.flatten!
 
       unless gauges.empty?
+        unless @only == :all
+          gauges.select! do |gauge|
+            @only.any? do |matcher|
+              matcher === gauge[:name]
+            end
+          end
+        end
+
+        unless @except == :none
+          gauges.reject! do |gauge|
+            @except.any? do |matcher|
+              matcher === gauge[:name]
+            end
+          end
+        end
+
         submit(form_data(gauges.flatten))
       end
     end


### PR DESCRIPTION
This differs from #19 in that I have a plethora of gauges but only report on a select few. I can't use `:only => [ :count ]` because I don't necessarily want _all_ counts. I would rather use `:only => [ 'my_app.count', 'my_app.95th_percentile' ]`.
