### PR TITLE
add support for derivative metrics

### DIFF
--- a/lib/metriks.rb
+++ b/lib/metriks.rb
@@ -1,4 +1,3 @@
-
 module Metriks
   VERSION = '0.9.9.1'
 
@@ -20,6 +19,10 @@ module Metriks
 
   def self.meter(name)
     Metriks::Registry.default.meter(name)
+  end
+
+  def self.derive(name)
+    Metriks::Registry.default.derive(name)
   end
 
   def self.histogram(name)

--- a/lib/metriks/derive.rb
+++ b/lib/metriks/derive.rb
@@ -1,6 +1,6 @@
 require 'atomic'
 
-require 'metriks/ewma'
+require 'metriks/meter'
 
 module Metriks
   class Derive < Metriks::Meter

--- a/lib/metriks/derive.rb
+++ b/lib/metriks/derive.rb
@@ -1,0 +1,13 @@
+require 'atomic'
+
+require 'metriks/ewma'
+
+module Metriks
+  class Derive < Metriks::Meter
+    def mark(val = 1)
+      @last ||= Atomic.new(val)
+      last = @last.swap(val)
+      super(last > val ? val : val - last)
+    end
+  end
+end

--- a/lib/metriks/registry.rb
+++ b/lib/metriks/registry.rb
@@ -2,6 +2,7 @@ require 'metriks/counter'
 require 'metriks/timer'
 require 'metriks/utilization_timer'
 require 'metriks/meter'
+require 'metriks/derive'
 
 module Metriks
   # Public: A collection of metrics
@@ -84,6 +85,21 @@ module Metriks
     # Returns the Metricks::Meter identified by the name.
     def meter(name)
       add_or_get(name, Metriks::Meter)
+    end
+
+    # Public: Fetch or create a new derivative metric. Derivatives are a meter
+    # that tracks throughput by calculating the derivative to the previous
+    # value.
+    #
+    # name - The String name of the metric to define or fetch
+    #
+    # Examples
+    #
+    #   registry.derive('network.bytes')
+    #
+    # Returns the Metricks::Derive identified by the name.
+    def derive(name)
+      add_or_get(name, Metriks::Derive)
     end
 
     # Public: Fetch or create a new timer metric. Timers provide the means to

--- a/test/derive_test.rb
+++ b/test/derive_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+
+require 'metriks/derive'
+
+class DeriveTest < Test::Unit::TestCase
+  include ThreadHelper
+
+  def setup
+    @meter = Metriks::Derive.new
+  end
+
+  def teardown
+    @meter.stop
+  end
+
+  def test_meter
+    @meter.mark(100)
+    @meter.mark(150)
+
+    assert_equal 50, @meter.count
+  end
+
+  def test_one_minute_rate
+    @meter.mark(1000)
+    @meter.mark(2000)
+
+    # Pretend it's been 5 seconds
+    @meter.tick
+
+    assert_equal 200, @meter.one_minute_rate
+  end
+end


### PR DESCRIPTION
A derivative metric is like a meter but accepts an absolute counter as
input. This is useful for metrics like bytes sent over the network or
cpu cycles which are generally monotonically increasing counters and
therefore need to be derived from the previous sample to get a useful
rate/s value.
