### PR TITLE
Close the tcp socket on Errno::EPIPE

### DIFF
--- a/lib/metriks/reporter/graphite.rb
+++ b/lib/metriks/reporter/graphite.rb
@@ -108,6 +108,8 @@ module Metriks::Reporter
           socket.write("#{base_name}.#{name} #{value} #{time}\n")
         end
       end
+    rescue Errno::EPIPE
+      socket.close
     end
   end
 end


### PR DESCRIPTION
This helps the graphite reporter to recover from an unavailable graphite carbon daemon. Without this it keeps spitting out EPIPEs even if the carbon daemon got back online.
