### PR TITLE
Riemann Reporter uses the right Metriks module

### DIFF
--- a/lib/metriks/reporter/riemann.rb
+++ b/lib/metriks/reporter/riemann.rb
@@ -8,7 +8,7 @@ module Metriks::Reporter
         :host => options[:host],
         :port => options[:port]
       )
-      @registry = options[:registry] || Metrics::Registry.default
+      @registry = options[:registry] || Metriks::Registry.default
       @interval = options[:interval] || 60
       @on_error = options[:on_error] || proc { |ex| }
       


### PR DESCRIPTION
The Riemann Reporter crashes because its referring to Metrics instead of Metriks.
