### PR TITLE
Custom percentile reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,19 @@ will display:
 
 [metriks-sematext](https://github.com/sematext/metriks-sematext) gem provides reporter for sending metrics to [SPM](http://sematext.com/spm/index.html).
 
+## Custom percentile reporting
+
+The Graphite, LibratoMetrics, Logger, and Riemann reporters all support
+reporting customized percentiles for histograms, timers, and utilization timers.
+By default, these reporters will report the p95 for these metric types.  The
+example below shows how to enable a custom set of percentile metrics
+
+``` ruby
+  Metriks::Reporter::Graphite.new('localhost', 3004, :percentiles => [:p95, :p99])
+```
+
+These percentiles are supported: `:p75, :p95, :p98, :p99, :p999`.
+
 # Application Server Configuration
 
 Depending on how your application server operates, you may need to configure how reporters are created. Please look at [Troubleshooting](https://github.com/eric/metriks/wiki/Troubleshooting) for more information.

--- a/lib/metriks/counter.rb
+++ b/lib/metriks/counter.rb
@@ -40,5 +40,23 @@ module Metriks
     def count
       @count.value
     end
+
+    # Public: An array of methods to be used for reporting metrics through a
+    # reporter.
+    #
+    # Returns an array of symbols of methods that can be called.
+    def self.reportable_metrics
+      [:count]
+    end
+
+    # Public: An array of methods to be used for reporting snapshot metrics
+    # through a reporter.
+    #
+    # options - No supported options.
+    #
+    # Returns an array of symbols of methods that can be called.
+    def self.reportable_snapshot_metrics(options = {})
+      []
+    end
   end
 end

--- a/lib/metriks/gauge.rb
+++ b/lib/metriks/gauge.rb
@@ -23,5 +23,23 @@ module Metriks
     def value
       @callback ? @callback.call : @gauge.value
     end
+
+    # Public: An array of methods to be used for reporting metrics through a
+    # reporter.
+    #
+    # Returns an array of symbols.
+    def self.reportable_metrics
+      [:value]
+    end
+
+    # Public: An array of methods to be used for reporting snapshot metrics
+    # through a reporter.
+    #
+    # options - No supported options.
+    #
+    # Returns an array of symbols.
+    def self.reportable_snapshot_metrics(options = {})
+      []
+    end
   end
 end

--- a/lib/metriks/histogram.rb
+++ b/lib/metriks/histogram.rb
@@ -108,5 +108,24 @@ module Metriks
         new_values
       end
     end
+
+    # Public: An array of methods to be used for reporting metrics through a
+    # reporter.
+    #
+    # Returns an array of symbols of methods that can be called.
+    def self.reportable_metrics
+      [:count, :min, :max, :mean, :stddev]
+    end
+
+    # Public: An array of methods to be used for reporting snapshot metrics
+    # through a reporter.
+    #
+    # options[:percentiles] - An array of percentiles methods to include. These
+    # must be valid methods on Metriks::Snapshot.
+    #
+    # Returns an array of symbols of methods that can be called.
+    def self.reportable_snapshot_metrics(options = {})
+      [:median] + options.fetch(:percentiles, [])
+    end
   end
 end

--- a/lib/metriks/meter.rb
+++ b/lib/metriks/meter.rb
@@ -81,5 +81,26 @@ module Metriks
 
     def stop
     end
+
+    # Public: An array of methods to be used for reporting metrics through a
+    # reporter.
+    #
+    # Returns an array of symbols of methods that can be called.
+    def self.reportable_metrics
+      [
+        :count, :one_minute_rate, :five_minute_rate, :fifteen_minute_rate,
+        :mean_rate
+      ]
+    end
+
+    # Public: An array of methods to be used for reporting snapshot metrics
+    # through a reporter.
+    #
+    # options - No supported options.
+    #
+    # Returns an array of symbols of methods that can be called.
+    def self.reportable_snapshot_metrics(options = {})
+      []
+    end
   end
 end

--- a/lib/metriks/snapshot.rb
+++ b/lib/metriks/snapshot.rb
@@ -1,5 +1,7 @@
 module Metriks
   class Snapshot
+    VALID_PERCENTILES = [:p75, :p95, :p98, :p99, :p999]
+
     MEDIAN_Q = 0.5
     P75_Q = 0.75
     P95_Q = 0.95
@@ -54,6 +56,29 @@ module Metriks
 
     def get_999th_percentile
       value(P999_Q)
+    end
+
+    def self.valid_percentile?(percentile)
+      VALID_PERCENTILES.include?(percentile)
+    end
+
+    # Public: Convert symbol percentiles into an array of methods to be called
+    # on a Snapshot object.
+    #
+    # percentiles - A symbol, or list of symbols, that represents the percentile
+    # that a method is needed for.
+    #
+    # Example:
+    #   Metriks::Snapshot.methods_for_percentiles(:p95, :p99)
+    #   # => [:get_95th_percentile, :get_99th_percentile]
+    #
+    # Returns an array of symbols
+    def self.methods_for_percentiles(*percentiles)
+      methods = percentiles.flatten.collect do |percentile|
+        next unless valid_percentile?(percentile)
+        :"get_#{percentile.to_s.gsub('p', '')}th_percentile"
+      end
+      methods.compact
     end
   end
 end

--- a/lib/metriks/timer.rb
+++ b/lib/metriks/timer.rb
@@ -97,5 +97,27 @@ module Metriks
     def stop
       @meter.stop
     end
+
+    # Public: An array of methods to be used for reporting metrics through a
+    # reporter.
+    #
+    # Returns an array of symbols of methods that can be called.
+    def self.reportable_metrics
+      [
+        :count, :one_minute_rate, :five_minute_rate, :fifteen_minute_rate,
+        :mean_rate, :min, :max, :mean, :stddev
+      ]
+    end
+
+    # Public: An array of methods to be used for reporting snapshot metrics
+    # through a reporter.
+    #
+    # options[:percentiles] - An array of percentiles methods to include. These
+    # must be valid methods on Metriks::Snapshot.
+    #
+    # Returns an array of symbols of methods that can be called.
+    def self.reportable_snapshot_metrics(options = {})
+      [:median] + options.fetch(:percentiles, [])
+    end
   end
 end

--- a/lib/metriks/utilization_timer.rb
+++ b/lib/metriks/utilization_timer.rb
@@ -39,5 +39,29 @@ module Metriks
       super
       @duration_meter.stop
     end
+
+    # Public: An array of methods to be used for reporting metrics through a
+    # reporter.
+    #
+    # Returns an array of symbols of methods that can be called.
+    def self.reportable_metrics
+      [
+        :count, :one_minute_rate, :five_minute_rate, :fifteen_minute_rate,
+        :mean_rate, :min, :max, :mean, :stddev, :one_minute_utilization,
+        :five_minute_utilization, :fifteen_minute_utilization,
+        :mean_utilization
+      ]
+    end
+
+    # Public: An array of methods to be used for reporting snapshot metrics
+    # through a reporter.
+    #
+    # options[:percentiles] - An array of percentiles methods to include. These
+    # must be valid methods on Metriks::Snapshot.
+    #
+    # Returns an array of symbols of methods that can be called.
+    def self.reportable_snapshot_metrics(options = {})
+      [:median] + options.fetch(:percentiles, [])
+    end
   end
 end

--- a/test/counter_test.rb
+++ b/test/counter_test.rb
@@ -36,4 +36,12 @@ class CounterTest < Test::Unit::TestCase
 
     assert_equal 10000, @counter.count
   end
+
+  def test_has_no_reportable_snapshot_metrics
+    assert_equal [], Metriks::Counter.reportable_snapshot_metrics
+  end
+
+  def test_has_reportable_metrics
+    assert_not_empty Metriks::Counter.reportable_metrics
+  end
 end

--- a/test/gauge_test.rb
+++ b/test/gauge_test.rb
@@ -43,4 +43,12 @@ class GaugeTest < Test::Unit::TestCase
 
     assert_equal 123, gauge.value
   end
+
+  def test_has_no_reportable_snapshot_metrics
+    assert_equal [], Metriks::Gauge.reportable_snapshot_metrics
+  end
+
+  def test_has_reportable_metrics
+    assert_not_empty Metriks::Gauge.reportable_metrics
+  end
 end

--- a/test/graphite_reporter_test.rb
+++ b/test/graphite_reporter_test.rb
@@ -38,4 +38,41 @@ class GraphiteReporterTest < Test::Unit::TestCase
     assert_match /gauge.testing.value 123/, @stringio.string
     assert_match /gauge.testing.block.value 456/, @stringio.string
   end
+
+  def test_custom_percentiles_for_timers
+    @reporter = build_reporter(:percentiles => :p999)
+    @registry.timer('timer.testing').update(1.5)
+    mock_snapshot = @registry.timer('timer.testing').snapshot
+    mock_snapshot.expects(:get_999th_percentile)
+    @registry.timer('timer.testing').stubs(:snapshot).returns(mock_snapshot)
+
+    @reporter.stubs(:socket).returns(@stringio)
+    @reporter.write
+  end
+
+  def test_custom_percentiles_for_utilization_timers
+    @reporter = build_reporter(:percentiles => :p999)
+    @registry.utilization_timer('utilization_timer.testing').update(1.5)
+    mock_snapshot = @registry.utilization_timer('utilization_timer.testing').snapshot
+    mock_snapshot.expects(:get_999th_percentile)
+    @registry.utilization_timer('utilization_timer.testing').stubs(:snapshot).returns(mock_snapshot)
+
+    @reporter.stubs(:socket).returns(@stringio)
+    @reporter.write
+  end
+
+  def test_custom_percentiles_for_histograms
+    @reporter = build_reporter(:percentiles => :p999)
+    @registry.histogram('histogram.testing').update(1.5)
+    mock_snapshot = @registry.histogram('histogram.testing').snapshot
+    mock_snapshot.expects(:get_999th_percentile)
+    @registry.histogram('histogram.testing').stubs(:snapshot).returns(mock_snapshot)
+
+    @reporter.stubs(:socket).returns(@stringio)
+    @reporter.write
+  end
+
+  def test_default_percentile
+    assert_equal [:get_95th_percentile], @reporter.percentile_methods
+  end
 end

--- a/test/histogram_test.rb
+++ b/test/histogram_test.rb
@@ -196,4 +196,12 @@ class HistogramTest < Test::Unit::TestCase
 
     assert_equal 5, @histogram.min
   end
+
+  def test_has_reportable_snapshot_metrics
+    assert_not_empty Metriks::Histogram.reportable_snapshot_metrics
+  end
+
+  def test_has_reportable_metrics
+    assert_not_empty Metriks::Histogram.reportable_metrics
+  end
 end

--- a/test/librato_metrics_reporter_test.rb
+++ b/test/librato_metrics_reporter_test.rb
@@ -32,4 +32,41 @@ class LibratoMetricsReporterTest < Test::Unit::TestCase
 
     @reporter.write
   end
+
+  def test_custom_percentiles_for_timers
+    @reporter = build_reporter(:percentiles => :p999)
+    @registry.timer('timer.testing').update(1.5)
+    mock_snapshot = @registry.timer('timer.testing').snapshot
+    mock_snapshot.expects(:get_999th_percentile)
+    @registry.timer('timer.testing').stubs(:snapshot).returns(mock_snapshot)
+
+    @reporter.stubs(:submit)
+    @reporter.write
+  end
+
+  def test_custom_percentiles_for_utilization_timers
+    @reporter = build_reporter(:percentiles => :p999)
+    @registry.utilization_timer('utilization_timer.testing').update(1.5)
+    mock_snapshot = @registry.utilization_timer('utilization_timer.testing').snapshot
+    mock_snapshot.expects(:get_999th_percentile)
+    @registry.utilization_timer('utilization_timer.testing').stubs(:snapshot).returns(mock_snapshot)
+
+    @reporter.stubs(:submit)
+    @reporter.write
+  end
+
+  def test_custom_percentiles_for_histograms
+    @reporter = build_reporter(:percentiles => :p999)
+    @registry.histogram('histogram.testing').update(1.5)
+    mock_snapshot = @registry.histogram('histogram.testing').snapshot
+    mock_snapshot.expects(:get_999th_percentile)
+    @registry.histogram('histogram.testing').stubs(:snapshot).returns(mock_snapshot)
+
+    @reporter.stubs(:submit)
+    @reporter.write
+  end
+
+  def test_default_percentile
+    assert_equal [:get_95th_percentile], @reporter.percentile_methods
+  end
 end

--- a/test/logger_reporter_test.rb
+++ b/test/logger_reporter_test.rb
@@ -46,4 +46,38 @@ class LoggerReporterTest < Test::Unit::TestCase
     assert_match /median=\d/, @stringio.string
     assert_match /value=123/, @stringio.string
   end
+
+def test_custom_percentiles_for_timers
+    @reporter = build_reporter(:percentiles => :p999)
+    @registry.timer('timer.testing').update(1.5)
+    mock_snapshot = @registry.timer('timer.testing').snapshot
+    mock_snapshot.expects(:get_999th_percentile)
+    @registry.timer('timer.testing').stubs(:snapshot).returns(mock_snapshot)
+
+    @reporter.write
+  end
+
+  def test_custom_percentiles_for_utilization_timers
+    @reporter = build_reporter(:percentiles => :p999)
+    @registry.utilization_timer('utilization_timer.testing').update(1.5)
+    mock_snapshot = @registry.utilization_timer('utilization_timer.testing').snapshot
+    mock_snapshot.expects(:get_999th_percentile)
+    @registry.utilization_timer('utilization_timer.testing').stubs(:snapshot).returns(mock_snapshot)
+
+    @reporter.write
+  end
+
+  def test_custom_percentiles_for_histograms
+    @reporter = build_reporter(:percentiles => :p999)
+    @registry.histogram('histogram.testing').update(1.5)
+    mock_snapshot = @registry.histogram('histogram.testing').snapshot
+    mock_snapshot.expects(:get_999th_percentile)
+    @registry.histogram('histogram.testing').stubs(:snapshot).returns(mock_snapshot)
+
+    @reporter.write
+  end
+
+  def test_default_percentile
+    assert_equal [:get_95th_percentile], @reporter.percentile_methods
+  end
 end

--- a/test/meter_test.rb
+++ b/test/meter_test.rb
@@ -35,4 +35,12 @@ class MeterTest < Test::Unit::TestCase
 
     assert_equal 200, @meter.one_minute_rate
   end
+
+  def test_has_no_reportable_snapshot_metrics
+    assert_equal [], Metriks::Meter.reportable_snapshot_metrics
+  end
+
+  def test_has_reportable_metrics
+    assert_not_empty Metriks::Meter.reportable_metrics
+  end
 end

--- a/test/riemann_reporter_test.rb
+++ b/test/riemann_reporter_test.rb
@@ -85,4 +85,41 @@ class RiemannReporterTest < Test::Unit::TestCase
 
     @reporter.write
   end
+
+def test_custom_percentiles_for_timers
+    @reporter = build_reporter(:percentiles => :p999)
+    @registry.timer('timer.testing').update(1.5)
+    mock_snapshot = @registry.timer('timer.testing').snapshot
+    mock_snapshot.expects(:get_999th_percentile)
+    @registry.timer('timer.testing').stubs(:snapshot).returns(mock_snapshot)
+
+    @reporter.stubs(:client).returns([])
+    @reporter.write
+  end
+
+  def test_custom_percentiles_for_utilization_timers
+    @reporter = build_reporter(:percentiles => :p999)
+    @registry.utilization_timer('utilization_timer.testing').update(1.5)
+    mock_snapshot = @registry.utilization_timer('utilization_timer.testing').snapshot
+    mock_snapshot.expects(:get_999th_percentile)
+    @registry.utilization_timer('utilization_timer.testing').stubs(:snapshot).returns(mock_snapshot)
+
+    @reporter.stubs(:client).returns([])
+    @reporter.write
+  end
+
+  def test_custom_percentiles_for_histograms
+    @reporter = build_reporter(:percentiles => :p999)
+    @registry.histogram('histogram.testing').update(1.5)
+    mock_snapshot = @registry.histogram('histogram.testing').snapshot
+    mock_snapshot.expects(:get_999th_percentile)
+    @registry.histogram('histogram.testing').stubs(:snapshot).returns(mock_snapshot)
+
+    @reporter.stubs(:client).returns([])
+    @reporter.write
+  end
+
+  def test_default_percentile
+    assert_equal [:get_95th_percentile], @reporter.percentile_methods
+  end
 end

--- a/test/snapshot_test.rb
+++ b/test/snapshot_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+require 'metriks/snapshot'
+
+class MetriksSnapshotTest < Test::Unit::TestCase
+  def test_skips_invalid_percentiles
+    methods = Metriks::Snapshot.methods_for_percentiles(:p999, :invalid_percentile)
+    assert_equal [:get_999th_percentile], methods
+  end
+
+  def test_multiple_percentiles
+    methods = Metriks::Snapshot.methods_for_percentiles(:p999, :p95)
+    assert_equal [:get_999th_percentile, :get_95th_percentile], methods
+  end
+end

--- a/test/timer_test.rb
+++ b/test/timer_test.rb
@@ -29,4 +29,12 @@ class TimerTest < Test::Unit::TestCase
 
     assert_in_delta 0.1, @timer.mean, 0.01
   end
+
+  def test_has_reportable_snapshot_metrics
+    assert_not_empty Metriks::Timer.reportable_snapshot_metrics
+  end
+
+  def test_has_reportable_metrics
+    assert_not_empty Metriks::Timer.reportable_metrics
+  end
 end

--- a/test/utilization_timer_test.rb
+++ b/test/utilization_timer_test.rb
@@ -22,4 +22,12 @@ class UtilizationTimerTest < Test::Unit::TestCase
 
     assert_in_delta 0.25, @timer.one_minute_utilization, 0.1
   end
+
+  def test_has_reportable_snapshot_metrics
+    assert_not_empty Metriks::UtilizationTimer.reportable_snapshot_metrics
+  end
+
+  def test_has_reportable_metrics
+    assert_not_empty Metriks::UtilizationTimer.reportable_metrics
+  end
 end


### PR DESCRIPTION
I set out to add an option to the Librato reporter so that custom/additional percentiles could be reported.  I ended up doing some refactoring for the lists of metrics supported for each metric type in various Reporters to reduce some duplication.

I added some tests I thought were helpful and added documentation where it made sense.  I'd love some feedback on this, so let me know!

Thanks!
