### PR TITLE
Add README example of timer with output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ or an object responding to `#call` (normally a `proc` or `lambda`).
 
 ``` ruby
   timer = Metriks.timer('requests')
-  timer.time do
+  work_result = timer.time do
     work
   end
 ```


### PR DESCRIPTION
It's pretty cool that metrik's default timer implementation has a much better UX than ruby's native Benchmark suite: it returns the output of the block, rather than a report. This makes it much easier to drop into various spots in an existing codebase without having to change much.

I had to go digging through the docs and then the source to confirm it though, so I thought an upfront example would help!
