### PR TITLE
Cleanup gemspec

### DIFF
--- a/metriks.gemspec
+++ b/metriks.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency('atomic', ["~> 1.0"])
   s.add_dependency('hitimes', [ "~> 1.1"])
-  s.add_dependency('avl_tree', [ "~> 1.1.2" ])
 
   s.add_development_dependency('mocha', ['~> 0.10'])
 


### PR DESCRIPTION
I've cleaned up gemspec mess and also removed dependency on `avl_tree`. Correct me if I'm wrong, but it looks like it's used only in `benchmark/samplers.rb` which shouldn't be included in gem bundle either way.
