### PR TITLE
Replace gem 'atomic' by 'concurrent-ruby'

### DIFF
--- a/lib/metriks/counter.rb
+++ b/lib/metriks/counter.rb
@@ -1,4 +1,4 @@
-require 'atomic'
+require 'concurrent/atomic'
 
 module Metriks
   # Public: Counters are one of the simplest metrics whose only operations
@@ -6,7 +6,7 @@ module Metriks
   class Counter
     # Public: Initialize a new Counter.
     def initialize
-      @count = Atomic.new(0)
+      @count = Concurrent::Atomic.new(0)
     end
 
     # Public: Reset the counter back to 0

--- a/lib/metriks/ewma.rb
+++ b/lib/metriks/ewma.rb
@@ -1,4 +1,4 @@
-require 'atomic'
+require 'concurrent/atomic'
 
 module Metriks
   class EWMA
@@ -30,8 +30,8 @@ module Metriks
       @interval = interval
 
       @initialized = false
-      @rate        = Atomic.new(0.0)
-      @uncounted   = Atomic.new(0)
+      @rate        = Concurrent::Atomic.new(0.0)
+      @uncounted   = Concurrent::Atomic.new(0)
     end
 
     def clear

--- a/lib/metriks/exponentially_decaying_sample.rb
+++ b/lib/metriks/exponentially_decaying_sample.rb
@@ -1,4 +1,4 @@
-require 'atomic'
+require 'concurrent/atomic'
 require 'red_black_tree'
 require 'metriks/snapshot'
 
@@ -8,8 +8,8 @@ module Metriks
 
     def initialize(reservoir_size, alpha, values = nil)
       @values = values || ConcurrentRedBlackTree.new
-      @count = Atomic.new(0)
-      @next_scale_time = Atomic.new(0)
+      @count = Concurrent::Atomic.new(0)
+      @next_scale_time = Concurrent::Atomic.new(0)
       @alpha = alpha
       @reservoir_size = reservoir_size
       @mutex = Mutex.new

--- a/lib/metriks/gauge.rb
+++ b/lib/metriks/gauge.rb
@@ -1,10 +1,10 @@
-require 'atomic'
+require 'concurrent/atomic'
 
 module Metriks
   class Gauge
     # Public: Initialize a new Gauge.
     def initialize(callable = nil, &block)
-      @gauge = Atomic.new(nil)
+      @gauge = Concurrent::Atomic.new(nil)
       @callback = callable || block
     end
 

--- a/lib/metriks/histogram.rb
+++ b/lib/metriks/histogram.rb
@@ -1,4 +1,4 @@
-require 'atomic'
+require 'concurrent/atomic'
 require 'metriks/uniform_sample'
 require 'metriks/exponentially_decaying_sample'
 
@@ -17,11 +17,11 @@ module Metriks
 
     def initialize(sample)
       @sample   = sample
-      @count    = Atomic.new(0)
-      @min      = Atomic.new(nil)
-      @max      = Atomic.new(nil)
-      @sum      = Atomic.new(0)
-      @variance = Atomic.new([ -1, 0 ])
+      @count    = Concurrent::Atomic.new(0)
+      @min      = Concurrent::Atomic.new(nil)
+      @max      = Concurrent::Atomic.new(nil)
+      @sum      = Concurrent::Atomic.new(0)
+      @variance = Concurrent::Atomic.new([ -1, 0 ])
     end
 
     def clear

--- a/lib/metriks/meter.rb
+++ b/lib/metriks/meter.rb
@@ -1,4 +1,4 @@
-require 'atomic'
+require 'concurrent/atomic'
 
 require 'metriks/ewma'
 
@@ -7,9 +7,9 @@ module Metriks
     TICK_INTERVAL = 5.0
 
     def initialize(averager_klass = Metriks::EWMA)
-      @count = Atomic.new(0)
+      @count = Concurrent::Atomic.new(0)
       @start_time = Time.now.to_f
-      @last_tick = Atomic.new(@start_time)
+      @last_tick = Concurrent::Atomic.new(@start_time)
 
       @m1_rate  = averager_klass.new_m1
       @m5_rate  = averager_klass.new_m5

--- a/lib/metriks/simple_moving_average.rb
+++ b/lib/metriks/simple_moving_average.rb
@@ -1,4 +1,4 @@
-require 'atomic'
+require 'concurrent/atomic'
 
 module Metriks
   class SimpleMovingAverage
@@ -25,8 +25,8 @@ module Metriks
       @interval = interval
       @duration = duration
 
-      @values = Array.new((duration / interval).to_i) { Atomic.new(nil) }
-      @index  = Atomic.new(0)
+      @values = Array.new((duration / interval).to_i) { Concurrent::Atomic.new(nil) }
+      @index  = Concurrent::Atomic.new(0)
     end
 
     def clear

--- a/lib/metriks/timer.rb
+++ b/lib/metriks/timer.rb
@@ -1,4 +1,4 @@
-require 'atomic'
+require 'concurrent/atomic'
 require 'hitimes'
 
 require 'metriks/meter'

--- a/lib/metriks/uniform_sample.rb
+++ b/lib/metriks/uniform_sample.rb
@@ -1,11 +1,11 @@
-require 'atomic'
+require 'concurrent/atomic'
 require 'metriks/snapshot'
 
 module Metriks
   class UniformSample
     def initialize(reservoir_size)
       @values = Array.new(reservoir_size, 0)
-      @count  = Atomic.new(0)
+      @count  = Concurrent::Atomic.new(0)
     end
 
     def clear

--- a/metriks.gemspec
+++ b/metriks.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
 
   ## List your runtime dependencies here. Runtime dependencies are those
   ## that are needed for an end user to actually USE your code.
-  s.add_dependency('atomic', ["~> 1.0"])
+  s.add_dependency('concurrent-ruby', ["~> 0.8"])
   s.add_dependency('hitimes', [ "~> 1.1"])
   s.add_dependency('avl_tree', [ "~> 1.2.0" ])
 


### PR DESCRIPTION
The gem `atomic` has been merged into `concurrent-ruby` and has been
deprecated.

This commit replaces the direct dependency on `atomic` with
`concurrent-ruby`.

The gem `avl_tree` still holds a dependency on `atomic` though.