### PR TITLE
Use concurrent-ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
+sudo: false
+dist: trusty
 language: ruby
+
 rvm:
-  - 1.8.7
-  - 1.9.2
   - 1.9.3
-  - ree
+  - 2.0
+  - 2.1
+  - 2.2
+  - 2.3
+  - 2.4

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'beefcake', '< 1.0.0'
 
 group :test do
   gem 'rake'
+  gem 'test-unit'
   gem 'riemann-client', '~> 0.0.7'
   gem 'rbtree', :platform => :mri_18
 end

--- a/lib/metriks.rb
+++ b/lib/metriks.rb
@@ -1,3 +1,4 @@
+require 'concurrent'
 
 module Metriks
   VERSION = '0.9.9.7'
@@ -29,6 +30,8 @@ module Metriks
   def self.histogram(name)
     Metriks::Registry.default.histogram(name)
   end
+
+  Atomic = Concurrent::AtomicReference
 end
 
 require 'metriks/registry'

--- a/lib/metriks/counter.rb
+++ b/lib/metriks/counter.rb
@@ -1,5 +1,3 @@
-require 'atomic'
-
 module Metriks
   # Public: Counters are one of the simplest metrics whose only operations
   # are increment and decrement.

--- a/lib/metriks/ewma.rb
+++ b/lib/metriks/ewma.rb
@@ -1,5 +1,3 @@
-require 'atomic'
-
 module Metriks
   class EWMA
     INTERVAL = 5.0

--- a/lib/metriks/exponentially_decaying_sample.rb
+++ b/lib/metriks/exponentially_decaying_sample.rb
@@ -1,4 +1,3 @@
-require 'atomic'
 require 'red_black_tree'
 require 'metriks/snapshot'
 

--- a/lib/metriks/gauge.rb
+++ b/lib/metriks/gauge.rb
@@ -1,5 +1,3 @@
-require 'atomic'
-
 module Metriks
   class Gauge
     # Public: Initialize a new Gauge.

--- a/lib/metriks/histogram.rb
+++ b/lib/metriks/histogram.rb
@@ -1,4 +1,3 @@
-require 'atomic'
 require 'metriks/uniform_sample'
 require 'metriks/exponentially_decaying_sample'
 

--- a/lib/metriks/meter.rb
+++ b/lib/metriks/meter.rb
@@ -1,5 +1,3 @@
-require 'atomic'
-
 require 'metriks/ewma'
 
 module Metriks

--- a/lib/metriks/simple_moving_average.rb
+++ b/lib/metriks/simple_moving_average.rb
@@ -1,5 +1,3 @@
-require 'atomic'
-
 module Metriks
   class SimpleMovingAverage
     INTERVAL = 5.0

--- a/lib/metriks/timer.rb
+++ b/lib/metriks/timer.rb
@@ -1,4 +1,4 @@
-require 'atomic'
+require 'concurrent'
 require 'hitimes'
 
 require 'metriks/meter'

--- a/lib/metriks/uniform_sample.rb
+++ b/lib/metriks/uniform_sample.rb
@@ -1,4 +1,4 @@
-require 'atomic'
+require 'concurrent'
 require 'metriks/snapshot'
 
 module Metriks

--- a/metriks.gemspec
+++ b/metriks.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
 
   ## List your runtime dependencies here. Runtime dependencies are those
   ## that are needed for an end user to actually USE your code.
-  s.add_dependency('atomic', ["~> 1.0"])
+  s.add_dependency('concurrent-ruby', ["~> 1.0"])
   s.add_dependency('hitimes', [ "~> 1.1"])
   s.add_dependency('avl_tree', [ "~> 1.2.0" ])
 

--- a/test/counter_test.rb
+++ b/test/counter_test.rb
@@ -28,7 +28,7 @@ class CounterTest < Test::Unit::TestCase
 
     assert_equal 10, @counter.count
   end
-  
+
   def test_increment_by_more_threaded
     thread 10, :n => 100 do
       @counter.increment 10

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,7 @@
 require 'test/unit'
 require 'pp'
 
-require 'mocha'
+require 'mocha/setup'
 
 require 'metriks'
 
@@ -17,7 +17,7 @@ module ThreadHelper
   def thread(threads = 2, opts = {})
     n = opts[:n] || 1
     results = []
-   
+
     threads.times.map do |i|
       Thread.new do
         n.times do
@@ -27,7 +27,7 @@ module ThreadHelper
     end.each do |thread|
       thread.join
     end
-    
+
     results
   end
 end


### PR DESCRIPTION
I'm not 100% certain, but my understanding is that `Concurrent:: AtomicReference` provides what `Atomic` used to be.